### PR TITLE
Fixed hamburger icon for mobile view

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -92,7 +92,7 @@ nav {
 .search-area {
     position: relative;
     width: 300px;
-    padding-left: 40px;
+    padding-left: 20px;
 }
 
 .search-area input {
@@ -146,8 +146,8 @@ nav {
 .hamburger {
     display: none;
     position: absolute;
-    right: 30px;
-    top: 46px;
+    left: 10px;
+    top: 30px;
     cursor: pointer;
     margin-left: 20px;
 }


### PR DESCRIPTION
Fixed hamburger icon for mobile view

Before screenshot: 
![image](https://github.com/user-attachments/assets/52db42e2-eb53-45b4-8ed7-4736a5c88dec)

After screenshot:
![image](https://github.com/user-attachments/assets/2984fe52-af51-454f-a43d-0670b2776623)

@devjainofficial I have fixed the bug. pls review this PR.