### PR TITLE
Made the copyright year dynamic

### DIFF
--- a/index.html
+++ b/index.html
@@ -453,7 +453,7 @@
         </li>
       </ul>
       <h3>Weather App</h3>
-      <p>Copyrights &copy; 2024</p>
+      <p>Copyrights &copy; <span id="year"></span></p>
     </footer>
   </div>
 
@@ -465,6 +465,7 @@
       script.src = 'js/modal.js';
       document.head.appendChild(script);
     }
+    document.getElementById('year').textContent = new Date().getFullYear();
   </script>
   <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
   <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>


### PR DESCRIPTION
## Description 
Updated the copyright text to display the current year dynamically using JavaScript. This ensures the year automatically updates every year without manual changes.

Closes #70 

## How to Test

- Open any page containing the copyright.
- Verify that the year displayed matches the current year.

## Screenshot 
<img width="1867" height="282" alt="image" src="https://github.com/user-attachments/assets/be248600-d8de-41b8-b68a-5c053e1f6b88" />
